### PR TITLE
fix : fic thai baht text check nect unit position

### DIFF
--- a/converter/constant.go
+++ b/converter/constant.go
@@ -11,8 +11,3 @@ type CurrencyFormat string
 const (
 	CURRENCY_FORMAT_THB CurrencyFormat = "thb"
 )
-
-var (
-	THAI_NUMBER_TEXTS = []string{"ศูนย์", "หนึ่ง", "สอง", "สาม", "สี่", "ห้า", "หก", "เจ็ด", "แปด", "เก้า", "สิบ"}
-	THAI_UNIT_TEXTS   = []string{"", "สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน"}
-)

--- a/converter/thb.go
+++ b/converter/thb.go
@@ -5,6 +5,13 @@ import (
 	"strings"
 )
 
+var (
+	THB_NUMBER_TEXTS   = []string{"ศูนย์", "หนึ่ง", "สอง", "สาม", "สี่", "ห้า", "หก", "เจ็ด", "แปด", "เก้า", "สิบ"}
+	THB_UNIT_TEXTS     = []string{"", "สิบ", "ร้อย", "พัน", "หมื่น", "แสน", "ล้าน"}
+	THB_PRIMARY_UNIT   = "บาท"
+	THB_SECONDARY_UNIT = "สตางค์"
+)
+
 func ConvertToThaiBahtText(num float64) string {
 	var currencyText string
 	if isZero(num) {
@@ -25,21 +32,27 @@ func getIntegerText(intValueStr string) string {
 	lengthOfDigit := len(runes)
 	numTextByPos := make([]string, lengthOfDigit)
 	for i := 0; i < lengthOfDigit; i++ {
-		numTextByPos[(lengthOfDigit-1)-i] = convertToThaiBaht(runes[i], i, lengthOfDigit)
+		nextUnitValue := rune(-1)
+		if i < lengthOfDigit-1 {
+			nextUnitValue = runes[(i + 1)]
+		}
+
+		numTextByPos[(lengthOfDigit-1)-i] = convertToThaiBaht(runes[i], nextUnitValue, i, lengthOfDigit)
 		if isMillionPosition(i) {
 			numTextByPos[(lengthOfDigit-1)-i] += millionUnitName(millionCount)
 		}
 	}
-	intText = strings.Join(numTextByPos[:], "")
+	intText = strings.Join(numTextByPos[:], "") + THB_PRIMARY_UNIT
 	return intText
 }
 
-func convertToThaiBaht(numChar rune, pos, lengthOfDigit int) string {
-	intVar, _ := strconv.Atoi(string(numChar))
+func convertToThaiBaht(unitValue, nextUnitValue rune, pos, lengthOfDigit int) string {
+	intVar, _ := strconv.Atoi(string(unitValue))
+	nextIntVar, _ := strconv.Atoi(string(nextUnitValue))
 	if isZero(float64(intVar)) {
 		return ""
 	}
-	numText := THAI_NUMBER_TEXTS[intVar]
+	numText := THB_NUMBER_TEXTS[intVar]
 	unitPos := getUnitPosition(pos)
 	if unitPos == TEN_POSITION && intVar == 2 {
 		numText = "ยี่"
@@ -47,11 +60,11 @@ func convertToThaiBaht(numChar rune, pos, lengthOfDigit int) string {
 	if unitPos == TEN_POSITION && intVar == 1 {
 		numText = ""
 	}
-	if lengthOfDigit > 1 && unitPos == UNIT_POSITION && intVar == 1 {
+	if lengthOfDigit > 1 && unitPos == UNIT_POSITION && intVar == 1 && nextIntVar != 0 {
 		numText = "เอ็ด"
 	}
 
-	unitText := THAI_UNIT_TEXTS[getUnitPosition(pos)]
+	unitText := THB_UNIT_TEXTS[getUnitPosition(pos)]
 
 	return numText + unitText
 }
@@ -59,7 +72,7 @@ func convertToThaiBaht(numChar rune, pos, lengthOfDigit int) string {
 func millionUnitName(millionCount int) string {
 	text := ""
 	for i := 0; i < millionCount; i++ {
-		text += THAI_UNIT_TEXTS[MILLION_POSITION]
+		text += THB_UNIT_TEXTS[MILLION_POSITION]
 	}
 	return text
 }

--- a/example/currency.go
+++ b/example/currency.go
@@ -9,9 +9,11 @@ import (
 func main() {
 	nums := []float64{
 		124000000000000,
+		124000000520000,
 		21,
 		10,
 		310,
+		501,
 	}
 	for _, n := range nums {
 		printNum(n)


### PR DESCRIPTION
What's new :  
- check next unit position value is not equal to zero for displaying the last unit position in Thai baht.